### PR TITLE
Configurable config file location

### DIFF
--- a/cmd/harvester/main.go
+++ b/cmd/harvester/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"time"
 
 	"github.com/OdysseyMomentumExperience/harvester/pkg/actors"
@@ -9,13 +10,15 @@ import (
 	"github.com/getsentry/sentry-go"
 )
 
-const configFileName = "config/harvester/config.dev.yaml"
-
 func main() {
 
 	var err error
 
-	cfg := harvester.GetConfig(configFileName, true)
+	configPath, ok := os.LookupEnv("CONFIG_PATH")
+	if !ok {
+		configPath = "config.yaml"
+	}
+	cfg := harvester.GetConfig(configPath, true)
 	cfg.PrettyPrint()
 
 	err = sentry.Init(sentry.ClientOptions{


### PR DESCRIPTION
It currently does't run, since it is pointing to a config file that does not exist in the built docker image.
Added CONFIG_PATH env, so it can always be pointed to this 'dev' config locally.