### PR TITLE
test era info

### DIFF
--- a/docker-compose.substrate.yaml
+++ b/docker-compose.substrate.yaml
@@ -1,0 +1,11 @@
+version: "3"
+
+services:
+  substrate:
+    container_name: substrate
+    image: parity/polkadot:v0.9.21
+    ports:
+      - 9933:9933
+      - 9944:9944
+      - 30333:30333
+    command: --dev --rpc-external --ws-external --rpc-methods Unsafe --offchain-worker Always

--- a/pkg/substrate/era_info_test.go
+++ b/pkg/substrate/era_info_test.go
@@ -1,0 +1,38 @@
+package substrate
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/OdysseyMomentumExperience/harvester/pkg/harvester"
+	"github.com/OdysseyMomentumExperience/harvester/pkg/mqtt"
+	"github.com/OdysseyMomentumExperience/harvester/pkg/wire"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEraInfo(t *testing.T) {
+	var cfg = harvester.Config{MQTT: mqtt.Config{Host: "localhost", Port: 1883, ClientId: "harvester"}}
+	var chainCfg = harvester.ChainConfig{Name: "harvester", RPC: "ws://localhost:9944", ActiveTopics: []string{}}
+	var h, _, _ = wire.NewHarvester(&cfg, func(err error) {})
+	var sh, _ = NewHarvester(chainCfg, h.Publisher, h.Repository)
+
+	t.Run("GetActiveEra", func(t *testing.T) {
+		activeEra, err := sh.GetActiveEra()
+		assert.Nil(t, err)
+		assert.Equal(t, reflect.TypeOf(activeEra).String(), reflect.Uint32.String())
+	})
+
+	t.Run("GetActiveEraDepth", func(t *testing.T) {
+		activeEraDepth, err := sh.GetActiveEraDepth()
+		assert.Nil(t, err)
+		assert.IsType(t, reflect.TypeOf(activeEraDepth), reflect.TypeOf([]byte("")))
+	})
+
+	t.Run("GetEraDepth", func(t *testing.T) {
+		activeEra, _ := sh.GetActiveEra()
+		eraDepth, err := sh.GetEraDepth(activeEra)
+		assert.Nil(t, err)
+		assert.IsType(t, reflect.TypeOf(eraDepth), reflect.TypeOf([]byte("")))
+	})
+
+}


### PR DESCRIPTION
## PR Description
- Add tests for `era info`

## How has this been tested?
- In order to run tests, make sure to start dependent services with `docker-compose -f docker-compose.substrate.yaml -f docker-compose.yaml up`
- Run `make test dir=./pkg/substrate`. If all tests run, a coverage report file will be generated in HTML format under `coverage/` folder at the root