### PR TITLE
test chain era state

### DIFF
--- a/pkg/substrate/chain_era_state.go
+++ b/pkg/substrate/chain_era_state.go
@@ -85,7 +85,7 @@ func (sh *SubstrateHarvester) GetErasValidatorReward(era uint32) (types.U128, er
 	var erasValidatorReward types.U128
 	err = sh.GetStorageLatest(erasValidatorRewardKey, &erasValidatorReward)
 
-	if err != nil {
+	if err != nil || erasValidatorReward.Int == nil {
 		return zeroReward, err
 	}
 

--- a/pkg/substrate/chain_era_state_test.go
+++ b/pkg/substrate/chain_era_state_test.go
@@ -1,0 +1,33 @@
+package substrate
+
+import (
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChainEraState(t *testing.T) {
+	t.Run("GetChainEraState", func(t *testing.T) {
+		activeEra, _ := sh.GetActiveEra()
+		err := sh.GetChainEraState(activeEra, uint32(1), uint32(1), func(err error) {})
+		assert.Nil(t, err)
+	})
+
+	t.Run("GetErasValidatorReward", func(t *testing.T) {
+		activeEra, _ := sh.GetActiveEra()
+		erasValidatorReward, err := sh.GetErasValidatorReward(activeEra)
+		assert.Nil(t, err)
+		assert.IsType(t, reflect.TypeOf(erasValidatorReward), reflect.TypeOf(types.NewU128(*big.NewInt(0))))
+	})
+
+	t.Run("getEraTotalStake", func(t *testing.T) {
+		activeEra, _ := sh.GetActiveEra()
+		totalStakeInEra, err := sh.getEraTotalStake(activeEra)
+		assert.Nil(t, err)
+		assert.IsType(t, reflect.TypeOf(totalStakeInEra), reflect.TypeOf(types.NewU128(*big.NewInt(0))))
+	})
+
+}

--- a/pkg/substrate/era_info_test.go
+++ b/pkg/substrate/era_info_test.go
@@ -4,18 +4,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/OdysseyMomentumExperience/harvester/pkg/harvester"
-	"github.com/OdysseyMomentumExperience/harvester/pkg/mqtt"
-	"github.com/OdysseyMomentumExperience/harvester/pkg/wire"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEraInfo(t *testing.T) {
-	var cfg = harvester.Config{MQTT: mqtt.Config{Host: "localhost", Port: 1883, ClientId: "harvester"}}
-	var chainCfg = harvester.ChainConfig{Name: "harvester", RPC: "ws://localhost:9944", ActiveTopics: []string{}}
-	var h, _, _ = wire.NewHarvester(&cfg, func(err error) {})
-	var sh, _ = NewHarvester(chainCfg, h.Publisher, h.Repository)
-
 	t.Run("GetActiveEra", func(t *testing.T) {
 		activeEra, err := sh.GetActiveEra()
 		assert.Nil(t, err)

--- a/pkg/substrate/harvester_test.go
+++ b/pkg/substrate/harvester_test.go
@@ -1,0 +1,12 @@
+package substrate
+
+import (
+	"github.com/OdysseyMomentumExperience/harvester/pkg/harvester"
+	"github.com/OdysseyMomentumExperience/harvester/pkg/mqtt"
+	"github.com/OdysseyMomentumExperience/harvester/pkg/wire"
+)
+
+var cfg = harvester.Config{MQTT: mqtt.Config{Host: "localhost", Port: 1883, ClientId: "harvester"}}
+var chainCfg = harvester.ChainConfig{Name: "harvester", RPC: "ws://localhost:9944", ActiveTopics: []string{}}
+var h, _, _ = wire.NewHarvester(&cfg, func(err error) {})
+var sh, _ = NewHarvester(chainCfg, h.Publisher, h.Repository)


### PR DESCRIPTION
## PR Description
- Add tests for `chain era state`

## How has this been tested?
- In order to run tests, make sure to start dependent services with `docker-compose -f docker-compose.substrate.yaml -f docker-compose.yaml up`
- Run `make test dir=./pkg/substrate`. If all tests run, a coverage report file will be generated in HTML format under `coverage/` folder at the root