### PR TITLE
test substrate/blocks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,9 +18,7 @@ chains:
     rpc: "wss://kusama-rpc.polkadot.io"
     active_topics:
       [
-        
-    
-       "block-creation-event",
+        "block-creation-event",
         "block-finalized-event",
         "reward-event",
         "society-members",
@@ -28,8 +26,7 @@ chains:
         "validators",
         "session",
         "slashes",
-        "era"
-      
+        "era",
       ]
   - name: "westend"
     type: "substrate"
@@ -60,12 +57,11 @@ sentry:
   attachStacktrace: true
 influx_db:
   url: http://localhost:8086
-  org: 
-  bucket: 
-  token: 
+  org:
+  bucket:
+  token:
   batchSize: 5
   retryInterval: 2
   systemMetricsInterval: 10
-
 
 loglevel: debug

--- a/pkg/substrate/blocks_test.go
+++ b/pkg/substrate/blocks_test.go
@@ -1,0 +1,162 @@
+package substrate
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/OdysseyMomentumExperience/harvester/pkg/harvester"
+	"github.com/OdysseyMomentumExperience/harvester/pkg/mqtt"
+	"github.com/OdysseyMomentumExperience/harvester/pkg/mysql"
+	"github.com/OdysseyMomentumExperience/harvester/pkg/publisher"
+	"github.com/OdysseyMomentumExperience/harvester/pkg/repository"
+	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlocks(t *testing.T) {
+	t.Run("ProcessNewHeader()", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(4 * time.Second)
+			ctx.Done()
+			cancel()
+		}()
+		err := mockSh.ProcessNewHeader(ctx, func(err error) {}, mockHarvester.PerformanceMonitorClient, "block-creation-event")
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "context canceled")
+	})
+
+	t.Run("ProcessFinalizedHeader()", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(4 * time.Second)
+			ctx.Done()
+			cancel()
+		}()
+		err := mockSh.ProcessFinalizedHeader(ctx, func(err error) {}, mockHarvester.PerformanceMonitorClient, "block-creation-event")
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "context canceled")
+	})
+
+	t.Run("fetchNewHead()", func(t *testing.T) {
+		latestNewHead, err := mockSh.fetchNewHead(func(err error) {}, mockHarvester.PerformanceMonitorClient, 0, "block-creation-event")
+		assert.Nil(t, err)
+		assert.IsType(t, latestNewHead, types.NewU32(0))
+	})
+
+	t.Run("fetchNewHead(): fail to process header", func(t *testing.T) {
+		newHead, _ := mockSh.api.RPC.Chain.GetHeaderLatest()
+		assert.IsType(t, newHead, &types.Header{})
+
+		_mqttClient := mqtt.GetMQTTClient(&mqtt.Config{}, func(err error) {})
+		_mockPublisher, _ := publisher.NewPublisher(_mqttClient)
+		_mockHarvester, _ := harvester.NewHarvester(&mockCfg, mockRepository, _mockPublisher, mockPmc)
+		_mockSh, _ := NewHarvester(mockChainCfg, _mockHarvester.Publisher, _mockHarvester.Repository)
+
+		latestNewHead, err := _mockSh.fetchNewHead(func(err error) {}, mockHarvester.PerformanceMonitorClient, 0, "block-creation-event")
+		assert.Equal(t, latestNewHead, types.NewU32(0))
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "error while processing new head")
+	})
+
+	t.Run("fetchFinalizedHead()", func(t *testing.T) {
+		finalizedHead, err := mockSh.fetchFinalizedHead(func(err error) {}, mockHarvester.PerformanceMonitorClient, 0, "block-finalized-event")
+		assert.Nil(t, err)
+		assert.IsType(t, finalizedHead, types.NewU32(0))
+	})
+
+	t.Run("fetchFinalizedHead(): fail to process finalized head", func(t *testing.T) {
+		finalizedHead, _ := mockSh.api.RPC.Chain.GetFinalizedHead()
+		assert.IsType(t, finalizedHead, types.Hash{})
+
+		_mqttClient := mqtt.GetMQTTClient(&mqtt.Config{}, func(err error) {})
+		_mockPublisher, _ := publisher.NewPublisher(_mqttClient)
+		_mockHarvester, _ := harvester.NewHarvester(&mockCfg, mockRepository, _mockPublisher, mockPmc)
+		_mockSh, _ := NewHarvester(mockChainCfg, _mockHarvester.Publisher, _mockHarvester.Repository)
+
+		latestNewHead, err := _mockSh.fetchFinalizedHead(func(err error) {}, mockHarvester.PerformanceMonitorClient, 0, "block-finalized-event")
+		assert.Equal(t, latestNewHead, types.NewU32(0))
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "error while processing finalized head")
+	})
+
+	t.Run("processHeader()", func(t *testing.T) {
+		newHead, _ := mockSh.api.RPC.Chain.GetHeaderLatest()
+		assert.IsType(t, newHead, &types.Header{})
+
+		err := mockSh.processHeader(newHead, "block-creation-event", false)
+		assert.Nil(t, err)
+	})
+
+	t.Run("processHeader(): publish header error", func(t *testing.T) {
+		topic := "block-creation-event"
+		newHead, _ := mockSh.api.RPC.Chain.GetHeaderLatest()
+		assert.IsType(t, newHead, &types.Header{})
+
+		_mqttClient := mqtt.GetMQTTClient(&mqtt.Config{}, func(err error) {})
+		_mockPublisher, _ := publisher.NewPublisher(_mqttClient)
+		_mockHarvester, _ := harvester.NewHarvester(&mockCfg, mockRepository, _mockPublisher, mockPmc)
+		_mockSh, _ := NewHarvester(mockChainCfg, _mockHarvester.Publisher, _mockHarvester.Repository)
+
+		err := _mockSh.processHeader(newHead, topic, false)
+		activeValidators, _ := mockSh.getCurrentSessionValidators()
+		validatorID, _ := accountIdToString(activeValidators[0])
+		assert.Equal(t, reflect.TypeOf(activeValidators), reflect.SliceOf(reflect.TypeOf(types.NewAccountID([]byte("")))))
+
+		errMsg := fmt.Errorf("publish header info for topic %v and validator %v is failed", topic, validatorID)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), errMsg.Error())
+	})
+
+	t.Run("publishHeader()", func(t *testing.T) {
+		newHead, _ := mockSh.api.RPC.Chain.GetHeaderLatest()
+		assert.IsType(t, newHead, &types.Header{})
+
+		activeValidators, _ := mockSh.getCurrentSessionValidators()
+		validatorID, _ := accountIdToString(activeValidators[0])
+		assert.Equal(t, reflect.TypeOf(activeValidators), reflect.SliceOf(reflect.TypeOf(types.NewAccountID([]byte("")))))
+
+		err := mockSh.publishHeader(newHead, 1, validatorID, "block-creation-event", false)
+		assert.Nil(t, err)
+	})
+
+	t.Run("publishHeader(): mqtt error", func(t *testing.T) {
+		newHead, _ := mockSh.api.RPC.Chain.GetHeaderLatest()
+		assert.IsType(t, newHead, &types.Header{})
+
+		activeValidators, _ := mockSh.getCurrentSessionValidators()
+		validatorID, _ := accountIdToString(activeValidators[0])
+		assert.Equal(t, reflect.TypeOf(activeValidators), reflect.SliceOf(reflect.TypeOf(types.NewAccountID([]byte("")))))
+
+		_mqttClient := mqtt.GetMQTTClient(&mqtt.Config{}, func(err error) {})
+		_mockPublisher, _ := publisher.NewPublisher(_mqttClient)
+		_mockHarvester, _ := harvester.NewHarvester(&mockCfg, mockRepository, _mockPublisher, mockPmc)
+		_mockSh, _ := NewHarvester(mockChainCfg, _mockHarvester.Publisher, _mockHarvester.Repository)
+
+		err := _mockSh.publishHeader(newHead, 1, validatorID, "block-creation-event", false)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "failed to publish message")
+	})
+
+	t.Run("publishHeader(): database error", func(t *testing.T) {
+		newHead, _ := mockSh.api.RPC.Chain.GetHeaderLatest()
+		assert.IsType(t, newHead, &types.Header{})
+
+		activeValidators, _ := mockSh.getCurrentSessionValidators()
+		validatorID, _ := accountIdToString(activeValidators[0])
+		assert.Equal(t, reflect.TypeOf(activeValidators), reflect.SliceOf(reflect.TypeOf(types.NewAccountID([]byte("")))))
+
+		_mockDB, _, _ := mysql.NewDB(&mysql.Config{})
+		_mockRepository, _ := repository.NewRepository(_mockDB, mockCfg.MySQL.Migrate)
+		_mockHarvester, _ := harvester.NewHarvester(&mockCfg, _mockRepository, mockPublisher, mockPmc)
+		_mockSh, _ := NewHarvester(mockChainCfg, _mockHarvester.Publisher, _mockHarvester.Repository)
+
+		err := _mockSh.publishHeader(newHead, 1, validatorID, "block-creation-event", false)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "dial tcp")
+	})
+
+}

--- a/pkg/substrate/chain_era_state_test.go
+++ b/pkg/substrate/chain_era_state_test.go
@@ -12,15 +12,15 @@ import (
 func TestChainEraState(t *testing.T) {
 
 	t.Run("GetErasValidatorReward", func(t *testing.T) {
-		activeEra, _ := sh.GetActiveEra()
-		erasValidatorReward, err := sh.GetErasValidatorReward(activeEra)
+		activeEra, _ := mockSh.GetActiveEra()
+		erasValidatorReward, err := mockSh.GetErasValidatorReward(activeEra)
 		assert.Nil(t, err)
 		assert.IsType(t, reflect.TypeOf(erasValidatorReward), reflect.TypeOf(types.NewU128(*big.NewInt(0))))
 	})
 
 	t.Run("getEraTotalStake", func(t *testing.T) {
-		activeEra, _ := sh.GetActiveEra()
-		totalStakeInEra, err := sh.getEraTotalStake(activeEra)
+		activeEra, _ := mockSh.GetActiveEra()
+		totalStakeInEra, err := mockSh.getEraTotalStake(activeEra)
 		assert.Nil(t, err)
 		assert.IsType(t, reflect.TypeOf(totalStakeInEra), reflect.TypeOf(types.NewU128(*big.NewInt(0))))
 	})

--- a/pkg/substrate/era_info_test.go
+++ b/pkg/substrate/era_info_test.go
@@ -9,20 +9,20 @@ import (
 
 func TestEraInfo(t *testing.T) {
 	t.Run("GetActiveEra", func(t *testing.T) {
-		activeEra, err := sh.GetActiveEra()
+		activeEra, err := mockSh.GetActiveEra()
 		assert.Nil(t, err)
 		assert.Equal(t, reflect.TypeOf(activeEra).String(), reflect.Uint32.String())
 	})
 
 	t.Run("GetActiveEraDepth", func(t *testing.T) {
-		activeEraDepth, err := sh.GetActiveEraDepth()
+		activeEraDepth, err := mockSh.GetActiveEraDepth()
 		assert.Nil(t, err)
 		assert.IsType(t, reflect.TypeOf(activeEraDepth), reflect.TypeOf([]byte("")))
 	})
 
 	t.Run("GetEraDepth", func(t *testing.T) {
-		activeEra, _ := sh.GetActiveEra()
-		eraDepth, err := sh.GetEraDepth(activeEra)
+		activeEra, _ := mockSh.GetActiveEra()
+		eraDepth, err := mockSh.GetEraDepth(activeEra)
 		assert.Nil(t, err)
 		assert.IsType(t, reflect.TypeOf(eraDepth), reflect.TypeOf([]byte("")))
 	})

--- a/pkg/substrate/getters_test.go
+++ b/pkg/substrate/getters_test.go
@@ -17,91 +17,91 @@ func hexToInt(hex string) (int64, error) {
 
 func TestGetters(t *testing.T) {
 	t.Run("GetStorageDataKey()", func(t *testing.T) {
-		key, err := sh.GetStorageDataKey("Session", "CurrentIndex")
+		key, err := mockSh.GetStorageDataKey("Session", "CurrentIndex")
 		assert.Greater(t, len(key), 0)
 		assert.Nil(t, err)
 
-		key, err = sh.GetStorageDataKey("a", "b")
+		key, err = mockSh.GetStorageDataKey("a", "b")
 		assert.Equal(t, len(key), 0)
 		assert.Contains(t, err.Error(), "module a not found")
 	})
 
 	t.Run("GetStorageLatest()", func(t *testing.T) {
-		key, _ := sh.GetStorageDataKey("Staking", "HistoryDepth")
+		key, _ := mockSh.GetStorageDataKey("Staking", "HistoryDepth")
 		var historyDepth types.U32
-		err := sh.GetStorageLatest(key, &historyDepth)
+		err := mockSh.GetStorageLatest(key, &historyDepth)
 		assert.Greater(t, historyDepth, types.U32(1))
 		assert.Nil(t, err)
 
 		var historyDepth2 int64
-		err = sh.GetStorageLatest(key, &historyDepth2)
+		err = mockSh.GetStorageLatest(key, &historyDepth2)
 		assert.Equal(t, historyDepth2, int64(0))
 		assert.NotNil(t, err)
 
 		var historyDepth3 types.U32
-		sh.GetStorageLatest(nil, &historyDepth3)
+		mockSh.GetStorageLatest(nil, &historyDepth3)
 		assert.Equal(t, historyDepth3, types.U32(0))
 	})
 
 	t.Run("GetChildKeysLatest()", func(t *testing.T) {
-		keys, err := sh.GetChildKeysLatest(nil, nil)
+		keys, err := mockSh.GetChildKeysLatest(nil, nil)
 		assert.Contains(t, err.Error(), "Method not found")
 		assert.Equal(t, len(keys), 0)
 	})
 
 	t.Run("GetKeysLatest()", func(t *testing.T) {
-		key, _ := sh.GetStorageDataKey("Staking", "HistoryDepth")
-		keys, err := sh.GetKeysLatest(key)
+		key, _ := mockSh.GetStorageDataKey("Staking", "HistoryDepth")
+		keys, err := mockSh.GetKeysLatest(key)
 		assert.Nil(t, err)
 		assert.Greater(t, len(keys), 0)
 		assert.IsType(t, &keys[0], &types.StorageKey{})
 	})
 
 	t.Run("GetStorageAtBlockHash()", func(t *testing.T) {
-		eraDepth, _ := sh.GetActiveEraDepth()
-		key, _ := sh.GetStorageDataKey("System", "BlockHash", eraDepth)
+		eraDepth := i32tob(0)
+		key, _ := mockSh.GetStorageDataKey("System", "BlockHash", eraDepth)
 		var blockHash1 types.H256
-		err := sh.GetStorageLatest(key, &blockHash1)
+		err := mockSh.GetStorageLatest(key, &blockHash1)
 		blockNumber, _ := hexToInt(blockHash1.Hex())
 		assert.Nil(t, err)
 		assert.Greater(t, blockNumber, int64(0))
 
 		hash, _ := types.NewHashFromHexString(blockHash1.Hex())
 		var blockHash2 types.H256
-		err = sh.GetStorageAtBlockHash(key, hash, &blockHash2)
+		err = mockSh.GetStorageAtBlockHash(key, hash, &blockHash2)
 		assert.Nil(t, err)
 		blockNumber, _ = hexToInt(blockHash2.Hex())
 		assert.Nil(t, err)
 		assert.Greater(t, blockNumber, int64(0))
 
 		var blockHash3 types.H256
-		err = sh.GetStorageAtBlockHash(key, types.NewHash([]byte("")), &blockHash3)
+		err = mockSh.GetStorageAtBlockHash(key, types.NewHash([]byte("")), &blockHash3)
 		blockNumber, _ = hexToInt(blockHash3.Hex())
 		assert.NotNil(t, err)
 		assert.Equal(t, blockNumber, int64(0))
 	})
 
 	t.Run("QueryStorage()", func(t *testing.T) {
-		newHead, _ := sh.api.RPC.Chain.GetHeaderLatest()
-		finalizedHead, _ := sh.api.RPC.Chain.GetFinalizedHead()
-		eraDepth, _ := sh.GetActiveEraDepth()
-		key, _ := sh.GetStorageDataKey("System", "BlockHash", eraDepth)
+		newHead, _ := mockSh.api.RPC.Chain.GetHeaderLatest()
+		finalizedHead, _ := mockSh.api.RPC.Chain.GetFinalizedHead()
+		eraDepth := i32tob(0)
+		key, _ := mockSh.GetStorageDataKey("System", "BlockHash", eraDepth)
 		var blockHash1 types.H256
-		err := sh.GetStorageLatest(key, &blockHash1)
+		err := mockSh.GetStorageLatest(key, &blockHash1)
 		blockNumber, _ := hexToInt(blockHash1.Hex())
 		assert.Nil(t, err)
 		assert.Greater(t, blockNumber, int64(0))
 
 		fromHash, _ := types.NewHashFromHexString(finalizedHead.Hex())
 		toHash, _ := types.NewHashFromHexString(finalizedHead.Hex())
-		changes, err := sh.QueryStorage([]types.StorageKey{key}, fromHash, toHash)
+		changes, err := mockSh.QueryStorage([]types.StorageKey{key}, fromHash, toHash)
 		assert.Nil(t, err)
 		assert.IsType(t, changes, []types.StorageChangeSet{})
 		assert.Greater(t, len(changes), 0)
 
 		fromHash, _ = types.NewHashFromHexString(newHead.StateRoot.Hex())
 		toHash, _ = types.NewHashFromHexString(newHead.StateRoot.Hex())
-		changes, err = sh.QueryStorage([]types.StorageKey{key}, fromHash, toHash)
+		changes, err = mockSh.QueryStorage([]types.StorageKey{key}, fromHash, toHash)
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), fromHash.Hex())
 		assert.Contains(t, err.Error(), toHash.Hex())
@@ -110,46 +110,46 @@ func TestGetters(t *testing.T) {
 
 	t.Run("QueryConstant()", func(t *testing.T) {
 		var sessionsPerEra types.U32
-		err := sh.QueryConstant("Staking", "SessionsPerEra", &sessionsPerEra)
+		err := mockSh.QueryConstant("Staking", "SessionsPerEra", &sessionsPerEra)
 		assert.Nil(t, err)
 		assert.IsType(t, sessionsPerEra, types.U32(0))
 
-		err = sh.QueryConstant("a", "b", &sessionsPerEra)
+		err = mockSh.QueryConstant("a", "b", &sessionsPerEra)
 		assert.NotNil(t, err)
 	})
 
 	t.Run("GetSessionLength()", func(t *testing.T) {
-		epochDuration, err := sh.GetSessionLength()
+		epochDuration, err := mockSh.GetSessionLength()
 		assert.Nil(t, err)
 		assert.IsType(t, epochDuration, types.U64(0))
 	})
 
 	t.Run("GetSlotDuration()", func(t *testing.T) {
-		slotDuration, err := sh.GetSlotDuration()
+		slotDuration, err := mockSh.GetSlotDuration()
 		assert.Nil(t, err)
 		assert.IsType(t, slotDuration, types.U64(0))
 	})
 
 	t.Run("GetSessionPerEra()", func(t *testing.T) {
-		sessionsPerEra, err := sh.GetSessionPerEra()
+		sessionsPerEra, err := mockSh.GetSessionPerEra()
 		assert.Nil(t, err)
 		assert.IsType(t, sessionsPerEra, types.NewU32(0))
 	})
 
 	t.Run("GetSessionIndex()", func(t *testing.T) {
-		sessionId, err := sh.GetSessionIndex()
+		sessionId, err := mockSh.GetSessionIndex()
 		assert.Nil(t, err)
 		assert.IsType(t, sessionId, types.NewU32(0))
 	})
 
 	t.Run("CreateStorageKeyUnsafe()", func(t *testing.T) {
-		keys, err := sh.CreateStorageKeyUnsafe("Staking", "Validators")
+		keys, err := mockSh.CreateStorageKeyUnsafe("Staking", "Validators")
 		assert.Nil(t, err)
 		assert.Greater(t, len(keys), 1)
 	})
 
 	t.Run("getCurrentSessionValidators()", func(t *testing.T) {
-		validatorAccountIDs, err := sh.getCurrentSessionValidators()
+		validatorAccountIDs, err := mockSh.getCurrentSessionValidators()
 		assert.Nil(t, err)
 		assert.IsType(t, &validatorAccountIDs[0], &types.AccountID{})
 		assert.Greater(t, len(validatorAccountIDs), 0)


### PR DESCRIPTION
## PR Description
- Add tests for `substrate/blocks`

## How has this been tested?
- In order to run tests, make sure to start dependent services with `docker-compose -f docker-compose.substrate.yaml -f docker-compose.yaml up`
- Run `make test dir=./pkg/substrate`. If all tests run, a coverage report file will be generated in HTML format under `coverage/` folder at the root