### PR TITLE
get active nominators

### DIFF
--- a/pkg/substrate/blocks_test.go
+++ b/pkg/substrate/blocks_test.go
@@ -103,7 +103,7 @@ func TestBlocks(t *testing.T) {
 
 		err := _mockSh.processHeader(newHead, topic, false)
 		activeValidators, _ := mockSh.getCurrentSessionValidators()
-		validatorID, _ := accountIdToString(activeValidators[0])
+		validatorID, _ := AccountIdToString(activeValidators[0])
 		assert.Equal(t, reflect.TypeOf(activeValidators), reflect.SliceOf(reflect.TypeOf(types.NewAccountID([]byte("")))))
 
 		errMsg := fmt.Errorf("publish header info for topic %v and validator %v is failed", topic, validatorID)
@@ -116,7 +116,7 @@ func TestBlocks(t *testing.T) {
 		assert.IsType(t, newHead, &types.Header{})
 
 		activeValidators, _ := mockSh.getCurrentSessionValidators()
-		validatorID, _ := accountIdToString(activeValidators[0])
+		validatorID, _ := AccountIdToString(activeValidators[0])
 		assert.Equal(t, reflect.TypeOf(activeValidators), reflect.SliceOf(reflect.TypeOf(types.NewAccountID([]byte("")))))
 
 		err := mockSh.publishHeader(newHead, 1, validatorID, "block-creation-event", false)
@@ -128,7 +128,7 @@ func TestBlocks(t *testing.T) {
 		assert.IsType(t, newHead, &types.Header{})
 
 		activeValidators, _ := mockSh.getCurrentSessionValidators()
-		validatorID, _ := accountIdToString(activeValidators[0])
+		validatorID, _ := AccountIdToString(activeValidators[0])
 		assert.Equal(t, reflect.TypeOf(activeValidators), reflect.SliceOf(reflect.TypeOf(types.NewAccountID([]byte("")))))
 
 		_mqttClient := mqtt.GetMQTTClient(&mqtt.Config{}, func(err error) {})
@@ -146,7 +146,7 @@ func TestBlocks(t *testing.T) {
 		assert.IsType(t, newHead, &types.Header{})
 
 		activeValidators, _ := mockSh.getCurrentSessionValidators()
-		validatorID, _ := accountIdToString(activeValidators[0])
+		validatorID, _ := AccountIdToString(activeValidators[0])
 		assert.Equal(t, reflect.TypeOf(activeValidators), reflect.SliceOf(reflect.TypeOf(types.NewAccountID([]byte("")))))
 
 		_mockDB, _, _ := mysql.NewDB(&mysql.Config{})

--- a/pkg/substrate/chain_era_state.go
+++ b/pkg/substrate/chain_era_state.go
@@ -17,6 +17,7 @@ type ChainEraState struct {
 	Name                  string     `json:"name"`
 	ActiveEra             uint32     `json:"activeEra"`
 	ActiveValidators      int        `json:"activeValidators"`
+	ActiveNominators      int        `json:"activeNominators"`
 	CandidateValidators   uint32     `json:"candidateValidators"`
 	TotalStakeInActiveEra types.U128 `json:"totalStakeInActiveEra"`
 	TotalStakeInLastEra   types.U128 `json:"totalStakeInLastEra"`
@@ -72,13 +73,17 @@ func (sh *SubstrateHarvester) publishEraInfo(fn harvester.ErrorHandler,
 
 	reward, err := sh.GetErasValidatorReward(activeEra - 1)
 	if err != nil {
-
 		return err
 	}
 
 	activeValidators, err := sh.getCurrentSessionValidators()
 	if err != nil {
-		return err
+		return errors.Wrap(err, " error while fetching activeValidators")
+	}
+
+	activeNominators, err := sh.getActiveNominators(fn)
+	if err != nil {
+		return errors.Wrap(err, " error while fetching activeNominators")
 	}
 
 	stakingRatio, err := sh.getStakingRatio(activeEra)
@@ -90,6 +95,7 @@ func (sh *SubstrateHarvester) publishEraInfo(fn harvester.ErrorHandler,
 		Name:                  sh.cfg.Name,
 		ActiveEra:             activeEra,
 		ActiveValidators:      len(activeValidators),
+		ActiveNominators:      len(activeNominators),
 		TotalStakeInActiveEra: totalStakeInActiveEra,
 		TotalStakeInLastEra:   totalStakeInLastEra,
 		LastEraReward:         reward,

--- a/pkg/substrate/getters_test.go
+++ b/pkg/substrate/getters_test.go
@@ -148,6 +148,14 @@ func TestGetters(t *testing.T) {
 		keys, err := mockSh.CreateStorageKeyUnsafe("Staking", "Validators")
 		assert.Nil(t, err)
 		assert.Greater(t, len(keys), 1)
+
+		keys, err = mockSh.CreateStorageKeyUnsafe("Staking", "ErasStakers", i32tob(0))
+		assert.Nil(t, err)
+		assert.Greater(t, len(keys), 1)
+
+		keys, err = mockSh.CreateStorageKeyUnsafe("Staking", "ErasStakerssss", i32tob(0))
+		assert.NotNil(t, err)
+		assert.Equal(t, len(keys), 0)
 	})
 
 	t.Run("getCurrentSessionValidators()", func(t *testing.T) {

--- a/pkg/substrate/harvester.go
+++ b/pkg/substrate/harvester.go
@@ -75,7 +75,6 @@ func (sh *SubstrateHarvester) getActiveProcesses() []harvester.TopicProcess {
 }
 
 func (sh *SubstrateHarvester) topicProcessorStore() func(string) harvester.ActiveHarvesterProcess {
-
 	innerProcessStore := map[string]harvester.ActiveHarvesterProcess{
 		"block-creation-event":  sh.ProcessNewHeader,
 		"block-finalized-event": sh.ProcessFinalizedHeader,

--- a/pkg/substrate/nominators.go
+++ b/pkg/substrate/nominators.go
@@ -1,0 +1,41 @@
+package substrate
+
+import (
+	"github.com/OdysseyMomentumExperience/harvester/pkg/harvester"
+	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
+)
+
+func (sh *SubstrateHarvester) getActiveNominators(fn harvester.ErrorHandler) ([]types.AccountID, error) {
+	eraDepth, _ := sh.GetActiveEraDepth()
+	k, err := sh.CreateStorageKeyUnsafe("Staking", "ErasStakers", eraDepth)
+	if err != nil {
+		return nil, err
+	}
+
+	stashKeys, err := sh.GetKeysLatest(k)
+	if err != nil {
+		return nil, err
+	}
+
+	changes, err := sh.QueryStorageAt(stashKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	var nominators []types.AccountID
+	for _, change := range changes {
+		var r types.Exposure
+		err = types.DecodeFromBytes(change.StorageData, &r)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, n := range r.Others {
+			if !Contains(nominators, n.Who) {
+				nominators = append(nominators, n.Who)
+			}
+		}
+	}
+
+	return nominators, nil
+}

--- a/pkg/substrate/nominators_test.go
+++ b/pkg/substrate/nominators_test.go
@@ -1,0 +1,18 @@
+package substrate
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNominators(t *testing.T) {
+	t.Run("getActiveNominators()", func(t *testing.T) {
+		nominators, err := mockSh.getActiveNominators(func(err error) {})
+		assert.NotNil(t, nominators)
+		assert.Nil(t, err)
+		assert.Equal(t, reflect.TypeOf(nominators), reflect.SliceOf(reflect.TypeOf(types.NewAccountID([]byte{}))))
+	})
+}

--- a/pkg/substrate/slashes.go
+++ b/pkg/substrate/slashes.go
@@ -79,7 +79,7 @@ func (sh *SubstrateHarvester) getSlashes(fn harvester.ErrorHandler,
 	}
 
 	for _, accountID := range validatorAccountIDs {
-		address, err := accountIdToString(accountID)
+		address, err := AccountIdToString(accountID)
 		if err != nil {
 			fn(err)
 			continue
@@ -111,7 +111,7 @@ func (sh *SubstrateHarvester) getSlashes(fn harvester.ErrorHandler,
 func (sh *SubstrateHarvester) getValidatorSlashInEra(era uint32, address string) (*ValidatorSlashInEra, error) {
 	var validatorSlashInEra ValidatorSlashInEra
 	eraDepth, _ := sh.GetEraDepth(era)
-	accountID, err := stringToAccountId(address)
+	accountID, err := StringToAccountId(address)
 
 	if err != nil {
 		return nil, err

--- a/pkg/substrate/utils.go
+++ b/pkg/substrate/utils.go
@@ -1,0 +1,48 @@
+package substrate
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
+	"github.com/decred/base58"
+	"github.com/vedhavyas/go-subkey"
+)
+
+func Contains(parent []types.AccountID, child types.AccountID) bool {
+	for _, value := range parent {
+		if value == child {
+			return true
+		}
+	}
+
+	return false
+}
+
+func UintsToBytes(vs []uint32) []byte {
+	buf := make([]byte, len(vs)*4)
+	for i, v := range vs {
+		binary.LittleEndian.PutUint32(buf[i*4:], v)
+	}
+	return buf
+}
+
+func AccountIdToString(id types.AccountID) (string, error) {
+	address, err := subkey.SS58Address(id[:], 2)
+	if err != nil {
+		return "", err
+	}
+
+	return address, nil
+}
+
+func StringToAccountId(account string) (types.AccountID, error) {
+	addressBytes := base58.Decode(account)
+	publicKey := addressBytes[1 : len(addressBytes)-2]
+	len := len(publicKey)
+	if len != 32 {
+		return types.NewAccountID(nil), fmt.Errorf("%s address yielded wrong length", account)
+	}
+
+	return types.NewAccountID(publicKey), nil
+}

--- a/pkg/substrate/utils_test.go
+++ b/pkg/substrate/utils_test.go
@@ -1,0 +1,46 @@
+package substrate
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUtils(t *testing.T) {
+	t.Run("Contains()", func(t *testing.T) {
+		accountsId := []types.AccountID{types.NewAccountID([]byte{1}), types.NewAccountID([]byte{2})}
+		assert.True(t, Contains(accountsId, types.NewAccountID([]byte{1})))
+		assert.False(t, Contains(accountsId, types.NewAccountID([]byte{100})))
+	})
+
+	t.Run("UintsToBytes()", func(t *testing.T) {
+		a, b := make([]byte, 4), make([]byte, 4)
+		binary.LittleEndian.PutUint32(a, 1)
+		binary.LittleEndian.PutUint32(b, 2)
+		assert.Equal(t, UintsToBytes([]uint32{1, 2}), append(a, b...))
+		assert.NotEqual(t, UintsToBytes([]uint32{1, 2, 3}), append(a, b...))
+	})
+
+	t.Run("AccountIdToString()", func(t *testing.T) {
+		a := types.NewAddressFromAccountID([]byte{1})
+		accountIdStr, err := AccountIdToString(a.AsAccountID)
+		accountId, _ := StringToAccountId(accountIdStr)
+		assert.Equal(t, a.AsAccountID, accountId)
+		assert.Nil(t, err)
+	})
+
+	t.Run("StringToAccountId()", func(t *testing.T) {
+		a := types.NewAddressFromAccountID([]byte{2})
+		accountIdStr, _ := AccountIdToString(a.AsAccountID)
+		accountId, err := StringToAccountId(accountIdStr)
+		assert.Equal(t, a.AsAccountID, accountId)
+		assert.Nil(t, err)
+
+		accountId, err = StringToAccountId("xxx")
+		assert.Equal(t, types.NewAccountID(nil), accountId)
+		assert.NotNil(t, err)
+		assert.Equal(t, err.Error(), "xxx address yielded wrong length")
+	})
+}


### PR DESCRIPTION
## PR Description
- Get active nominators

## How has this been tested?
- Start dependent services with this command `docker-compose up`
- Start the application with this command `go run ./cmd/harvester`
- A key called `activeNominators` will be available  in the `era` MQTT message
- In order to run tests, make sure to start dependent services with `docker-compose -f docker-compose.substrate.yaml -f docker-compose.yaml up`, then run `make test dir=./pkg/substrate`. If all tests run, a coverage report file will be generated in HTML format under `coverage/` folder at the root