### PR TITLE
get staking ratio

### DIFF
--- a/pkg/substrate/chain_era_state_test.go
+++ b/pkg/substrate/chain_era_state_test.go
@@ -25,4 +25,10 @@ func TestChainEraState(t *testing.T) {
 		assert.IsType(t, reflect.TypeOf(totalStakeInEra), reflect.TypeOf(types.NewU128(*big.NewInt(0))))
 	})
 
+	t.Run("getStakingRatio", func(t *testing.T) {
+		activeEra, _ := mockSh.GetActiveEra()
+		stakingRatio, err := mockSh.getStakingRatio(activeEra)
+		assert.Nil(t, err)
+		assert.IsType(t, reflect.TypeOf(stakingRatio), reflect.TypeOf(float32(0)))
+	})
 }

--- a/pkg/substrate/getters.go
+++ b/pkg/substrate/getters.go
@@ -137,3 +137,18 @@ func (sh *SubstrateHarvester) getCurrentSessionValidators() ([]types.AccountID, 
 
 	return validatorAccountIDs, nil
 }
+
+func (sh *SubstrateHarvester) GetTotalIssuance() (types.U128, error) {
+	var totalIssuance types.U128
+	key, err := sh.GetStorageDataKey("Balances", "TotalIssuance")
+	if err != nil {
+		return totalIssuance, err
+	}
+
+	err = sh.GetStorageLatest(key, &totalIssuance)
+	if err != nil {
+		return totalIssuance, err
+	}
+
+	return totalIssuance, nil
+}

--- a/pkg/substrate/getters_test.go
+++ b/pkg/substrate/getters_test.go
@@ -1,6 +1,8 @@
 package substrate
 
 import (
+	"math/big"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -153,5 +155,12 @@ func TestGetters(t *testing.T) {
 		assert.Nil(t, err)
 		assert.IsType(t, &validatorAccountIDs[0], &types.AccountID{})
 		assert.Greater(t, len(validatorAccountIDs), 0)
+	})
+
+	t.Run("GetTotalIssuance()", func(t *testing.T) {
+		totalIssuance, err := mockSh.GetTotalIssuance()
+		assert.Nil(t, err)
+		assert.IsType(t, reflect.TypeOf(totalIssuance), reflect.TypeOf(types.NewU128(*big.NewInt(0))))
+		assert.Greater(t, totalIssuance.Uint64(), uint64(0))
 	})
 }


### PR DESCRIPTION
## PR Description
- Get staking ratio

## How has this been tested?
- Start dependent services with this command `docker-compose up`
- Start the application with this command `go run ./cmd/harvester`
- A key called `stakingRatio` will be available in the era MQTT message
- In order to run tests, make sure to start dependent services with `docker-compose -f docker-compose.substrate.yaml -f docker-compose.yaml up`, then run `make test dir=./pkg/substrate`. If all tests run, a coverage report file will be generated in HTML format under `coverage/` folder at the root